### PR TITLE
More options when creating new configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ _testmain.go
 *.test
 *.prof
 .vscode
+
+# OS generated files
+.DS_Store
+
+# IDEA files
+**/.idea

--- a/configuration.go
+++ b/configuration.go
@@ -55,12 +55,17 @@ type Configuration struct {
 }
 
 // NewConfiguration create new configuration
-func NewConfiguration(basePath string) *Configuration {
+func NewConfiguration(basePath string, options ...func(*Configuration)) *Configuration {
 	cfg := &Configuration{
 		BasePath:      basePath,
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "go-bitbucket/1.0.0/go",
 	}
+
+	for _, option := range options {
+		option(cfg)
+	}
+
 	return cfg
 }
 


### PR DESCRIPTION
This PR provides the option to pass additional parameters to NewConfiguration. As an example, you can pass the following preconfigured [HttpClient](https://github.com/gfleury/go-bitbucket-v1/blob/master/configuration.go#L54) to disable verification of server's certificate chain and host name.
```
tr := &http.Transport{
    TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
}
httpClient := &http.Client{
    Transport: tr,
}
httpClientConfig := func(configs *bitbucketv1.Configuration) {
    configs.HTTPClient = httpClient
}

client := bitbucketv1.NewAPIClient(
    ctx,
    bitbucketv1.NewConfiguration("https://stash.domain.com/rest", httpClientConfig),
)
```

This implementation is using [functional options](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) thus making the API easily configurable, extendable, and backwards compatible.