### PR TITLE
fix: add additional params to UpdateWebhook

### DIFF
--- a/default_api.go
+++ b/default_api.go
@@ -12310,24 +12310,22 @@ Update an existing webhook.  &lt;p&gt;  The authenticated user must have &lt;str
 * @param ctx context.Context for authentication, logging, tracing, etc.
 @param webhookId the existing webhook id
 @return */
-func (a *DefaultApiService) UpdateWebhook(webhookId int32) (*APIResponse, error) {
+func (a *DefaultApiService) UpdateWebhook(projectKey, repositorySlug string, webhookId int32, localVarPostBody interface{}, localVarHTTPContentTypes []string) (*APIResponse, error) {
 	var (
 		localVarHTTPMethod = strings.ToUpper("Put")
-		localVarPostBody   interface{}
 		localVarFileName   string
 		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/api/1.0/projects/{projectKey}/repos/{repositorySlug}/webhooks/{webhookId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"projectKey"+"}", fmt.Sprintf("%v", projectKey), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"repositorySlug"+"}", fmt.Sprintf("%v", repositorySlug), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"webhookId"+"}", fmt.Sprintf("%v", webhookId), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-
-	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)

--- a/default_api_test.go
+++ b/default_api_test.go
@@ -6576,7 +6576,11 @@ func TestDefaultApiService_UpdateWebhook(t *testing.T) {
 		client *APIClient
 	}
 	type args struct {
-		webhookId int32
+		projectKey               string
+		repositorySlug           string
+		webhookId                int32
+		localVarPostBody         interface{}
+		localVarHTTPContentTypes []string
 	}
 	tests := []struct {
 		name    string
@@ -6592,7 +6596,7 @@ func TestDefaultApiService_UpdateWebhook(t *testing.T) {
 			a := &DefaultApiService{
 				client: tt.fields.client,
 			}
-			got, err := a.UpdateWebhook(tt.args.webhookId)
+			got, err := a.UpdateWebhook(tt.args.projectKey, tt.args.repositorySlug, tt.args.webhookId, tt.args.localVarPostBody, tt.args.localVarHTTPContentTypes)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DefaultApiService.UpdateWebhook() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
It is now essentially the same as `CreateWebhook` but it takes an additional `webhookId` parameter.