### PR TITLE
Fix GetArchive - the API that downloads an archive of a repository

### DIFF
--- a/api_response.go
+++ b/api_response.go
@@ -125,7 +125,7 @@ type PullRequestRef struct {
 
 type PullRequest struct {
 	ID           int                `json:"id"`
-	Version      int32                `json:"version"`
+	Version      int32              `json:"version"`
 	Title        string             `json:"title"`
 	Description  string             `json:"description"`
 	State        string             `json:"state"`
@@ -242,6 +242,47 @@ type Branch struct {
 	LatestCommit    string `json:"latestCommit"`
 	LatestChangeset string `json:"latestChangeset"`
 	IsDefault       bool   `json:"isDefault"`
+}
+
+/**
+
+https://docs.atlassian.com/bitbucket-server/rest/5.5.2/bitbucket-access-tokens-rest.html
+{
+    "id": "252973515069",
+    "createdDate": 1503289426223,
+    "lastAuthenticated": 1503289517336,
+    "name": "token name",
+    "permissions": [
+        "REPO_ADMIN",
+        "PROJECT_READ"
+    ],
+    "user": {
+        "name": "jcitizen",
+        "emailAddress": "jane@example.com",
+        "id": 101,
+        "displayName": "Jane Citizen",
+        "active": true,
+        "slug": "jcitizen",
+        "type": "NORMAL"
+    },
+    "token": "MjUyOTczNTE1MDY5On2rDbID2EgYpH8AVOECHv0saruQ"
+}
+*/
+type AccessTokenResponse struct {
+	ID                string   `json:"id"`
+	CreatedDate       int64    `json:"createdDate"`
+	LastAuthenticated int64    `json:"lastAuthenticated"`
+	Name              string   `json:"name"`
+	Permissions       []string `json:"permissions"`
+	User              User     `json:"user"`
+	Token             string   `json:"token"`
+}
+
+// GetAccessTokenResponse cast AccessTokenResponse into structure
+func GetAccessTokenResponse(r *APIResponse) (AccessTokenResponse, error) {
+	var m AccessTokenResponse
+	err := mapstructure.Decode(r.Values, &m)
+	return m, err
 }
 
 func (k *SSHKey) String() string {

--- a/default_api.go
+++ b/default_api.go
@@ -2755,7 +2755,7 @@ func (a *DefaultApiService) ForkRepository(projectKey, repositorySlug string,
 	defer localVarHTTPResponse.Body.Close()
 	if localVarHTTPResponse.StatusCode >= 300 {
 		bodyBytes, _ := ioutil.ReadAll(localVarHTTPResponse.Body)
-		return NewAPIResponseWithError(localVarHTTPResponse, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
+		return NewAPIResponseWithError(localVarHTTPResponse, reportError("Status: %s, Url: %s, Body: %s", localVarHTTPResponse.Status, localVarPath, bodyBytes))
 	}
 
 	return NewBitbucketAPIResponse(localVarHTTPResponse)

--- a/default_api.go
+++ b/default_api.go
@@ -2973,7 +2973,7 @@ func (a *DefaultApiService) GetArchive(project, repository string, localVarOptio
 	}
 
 	//localVarPath := a.client.cfg.BasePath + "/api/1.0/projects/{projectKey}/repos/{repositorySlug}/archive"
-	localVarPath := a.client.cfg.BasePath + apibasepath +"/projects/{projectKey}/repos/{repositorySlug}/archive"
+	localVarPath := a.client.cfg.BasePath + apibasepath + "/projects/{projectKey}/repos/{repositorySlug}/archive"
 	localVarPath = strings.Replace(localVarPath, "{"+"projectKey"+"}", fmt.Sprintf("%v", project), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"repositorySlug"+"}", fmt.Sprintf("%v", repository), -1)
 
@@ -4142,12 +4142,9 @@ func (a *DefaultApiService) GetRawContent(projectKey, repositorySlug, path strin
 		localVarFileName   string
 		localVarFileBytes  []byte
 	)
-
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/" + projectKey + "/repos/" + repositorySlug + "/raw/" + path
 	localVarPath = strings.Replace(localVarPath, "/rest/", "/projects/", 1)
-	// https://bitbucket.global.standardchartered.com/projects/CISO/repos/planes/raw/enactments/tes_mattermost.yaml?at=refs%2Fheads%2Fstate%2Fdev
-	// https://bitbucket.global.standardchartered.com/projects/CISO/repos/planes/raw/enactments/tes_mattermost.yaml?at=refs%2Fheads%2Fstate%2Fdev
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
@@ -4704,65 +4701,65 @@ func (a *DefaultApiService) GetGroupsWithoutAnyPermission_14(localVarOptionals m
 
 // AddRepositoryPermissionGroup https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8297426496
 func (a *DefaultApiService) SetRepositoryPermissionGroups(projectKey, repositorySlug, permission string, groupNames []string, localVarHTTPContentTypes []string) (*APIResponse, error) {
-    var (
-        localVarHTTPMethod = strings.ToUpper("Put")
-        localVarFileName   string
-        localVarFileBytes  []byte
-        localVarPostBody   interface{}
-    )
+	var (
+		localVarHTTPMethod = strings.ToUpper("Put")
+		localVarFileName   string
+		localVarFileBytes  []byte
+		localVarPostBody   interface{}
+	)
 
-    // create path and map variables
-    localVarPath := a.client.cfg.BasePath + "/api/1.0/projects/{projectKey}/repos/{repositorySlug}/permissions/groups"
-    localVarPath = strings.Replace(localVarPath, "{"+"projectKey"+"}", fmt.Sprintf("%v", projectKey), -1)
-    localVarPath = strings.Replace(localVarPath, "{"+"repositorySlug"+"}", fmt.Sprintf("%v", repositorySlug), -1)
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/api/1.0/projects/{projectKey}/repos/{repositorySlug}/permissions/groups"
+	localVarPath = strings.Replace(localVarPath, "{"+"projectKey"+"}", fmt.Sprintf("%v", projectKey), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"repositorySlug"+"}", fmt.Sprintf("%v", repositorySlug), -1)
 
-    localVarHeaderParams := make(map[string]string)
-    localVarQueryParams := url.Values{
-        "name":       groupNames,
-        "permission": []string{permission},
-    }
-    localVarFormParams := url.Values{}
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{
+		"name":       groupNames,
+		"permission": []string{permission},
+	}
+	localVarFormParams := url.Values{}
 
-    // set Content-Type header
-    localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
-    if localVarHTTPContentType != "" {
-        localVarHeaderParams["Content-Type"] = localVarHTTPContentType
-    }
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
 
-    // to determine the Accept header
-    localVarHTTPHeaderAccepts := []string{}
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
 
-    // set Accept header
-    localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
-    if localVarHTTPHeaderAccept != "" {
-        localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-    }
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
 
-    r, err := a.client.prepareRequest(a.client.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
-    if err != nil {
-        return nil, err
-    }
+	r, err := a.client.prepareRequest(a.client.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
 
-    localVarHTTPResponse, err := a.client.callAPI(r)
-    if err != nil {
-        if localVarHTTPResponse != nil {
-            return NewBitbucketAPIResponse(localVarHTTPResponse)
-        }
-        return nil, err
-    }
-    if localVarHTTPResponse == nil {
-        return nil, nil
-    }
-    defer localVarHTTPResponse.Body.Close()
-    if localVarHTTPResponse.StatusCode >= 300 {
-        bodyBytes, _ := ioutil.ReadAll(localVarHTTPResponse.Body)
-        return NewAPIResponseWithError(localVarHTTPResponse, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
-    }
-    if localVarHTTPResponse.StatusCode == 204 {
-        return nil, nil
-    }
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil {
+		if localVarHTTPResponse != nil {
+			return NewBitbucketAPIResponse(localVarHTTPResponse)
+		}
+		return nil, err
+	}
+	if localVarHTTPResponse == nil {
+		return nil, nil
+	}
+	defer localVarHTTPResponse.Body.Close()
+	if localVarHTTPResponse.StatusCode >= 300 {
+		bodyBytes, _ := ioutil.ReadAll(localVarHTTPResponse.Body)
+		return NewAPIResponseWithError(localVarHTTPResponse, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
+	}
+	if localVarHTTPResponse.StatusCode == 204 {
+		return nil, nil
+	}
 
-    return NewBitbucketAPIResponse(localVarHTTPResponse)
+	return NewBitbucketAPIResponse(localVarHTTPResponse)
 }
 
 /* DefaultApiService

--- a/default_api.go
+++ b/default_api.go
@@ -13062,7 +13062,7 @@ func (a *DefaultApiService) GetHeadCommit(project, repository, branch string, lo
 		apibasepath = "/api/1.0" // or "apibasepath": "/api/latest"
 	}
 
-	localVarPath := a.client.cfg.BasePath + apibasepath + "/projects/{projectKey}/repos/{repositorySlug}/commits?at=refs/heads/{branch}&start=0&limit=1"
+	localVarPath := a.client.cfg.BasePath + apibasepath + "/projects/{projectKey}/repos/{repositorySlug}/commits?until=refs/heads/{branch}&start=0&limit=1"
 	localVarPath = strings.Replace(localVarPath, "{"+"projectKey"+"}", fmt.Sprintf("%v", project), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"repositorySlug"+"}", fmt.Sprintf("%v", repository), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"branch"+"}", fmt.Sprintf("%v", branch), -1)

--- a/default_api.go
+++ b/default_api.go
@@ -4702,6 +4702,69 @@ func (a *DefaultApiService) GetGroupsWithoutAnyPermission_14(localVarOptionals m
 	return NewBitbucketAPIResponse(localVarHTTPResponse)
 }
 
+// AddRepositoryPermissionGroup https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8297426496
+func (a *DefaultApiService) SetRepositoryPermissionGroups(projectKey, repositorySlug, permission, groupNames []string, localVarHTTPContentTypes []string) (*APIResponse, error) {
+    var (
+        localVarHTTPMethod = strings.ToUpper("Put")
+        localVarFileName   string
+        localVarFileBytes  []byte
+        localVarPostBody   interface{}
+    )
+
+    // create path and map variables
+    localVarPath := a.client.cfg.BasePath + "/api/1.0/projects/{projectKey}/repos/{repositorySlug}/permissions/groups"
+    localVarPath = strings.Replace(localVarPath, "{"+"projectKey"+"}", fmt.Sprintf("%v", projectKey), -1)
+    localVarPath = strings.Replace(localVarPath, "{"+"repositorySlug"+"}", fmt.Sprintf("%v", repositorySlug), -1)
+
+    localVarHeaderParams := make(map[string]string)
+    localVarQueryParams := url.Values{
+        "name":       groupNames,
+        "permission": []string{permission},
+    }
+    localVarFormParams := url.Values{}
+
+    // set Content-Type header
+    localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+    if localVarHTTPContentType != "" {
+        localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+    }
+
+    // to determine the Accept header
+    localVarHTTPHeaderAccepts := []string{}
+
+    // set Accept header
+    localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+    if localVarHTTPHeaderAccept != "" {
+        localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+    }
+
+    r, err := a.client.prepareRequest(a.client.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+    if err != nil {
+        return nil, err
+    }
+
+    localVarHTTPResponse, err := a.client.callAPI(r)
+    if err != nil {
+        if localVarHTTPResponse != nil {
+            return NewBitbucketAPIResponse(localVarHTTPResponse)
+        }
+        return nil, err
+    }
+    if localVarHTTPResponse == nil {
+        return nil, nil
+    }
+    defer localVarHTTPResponse.Body.Close()
+    if localVarHTTPResponse.StatusCode >= 300 {
+        bodyBytes, _ := ioutil.ReadAll(localVarHTTPResponse.Body)
+        return NewAPIResponseWithError(localVarHTTPResponse, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
+    }
+    if localVarHTTPResponse.StatusCode == 204 {
+        return nil, nil
+    }
+
+    return NewBitbucketAPIResponse(localVarHTTPResponse)
+}
+
 /* DefaultApiService
  Retrieve a page of groups that have no granted permissions for the specified repository.  &lt;p&gt;  The authenticated user must have &lt;strong&gt;REPO_ADMIN&lt;/strong&gt; permission for the specified repository or a higher  project or global permission to call this resource.
  * @param ctx context.Context for authentication, logging, tracing, etc.

--- a/default_api.go
+++ b/default_api.go
@@ -7606,7 +7606,9 @@ func (a *DefaultApiService) CreateSSHKey(localVarOptionals map[string]interface{
 		localVarQueryParams.Add("user", parameterToString(localVarTempParam, ""))
 	}
 	if localVarTempParam, localVarOk := localVarOptionals["text"].(string); localVarOk {
-		localVarFormParams.Add("text", parameterToString(localVarTempParam, ""))
+		localVarPostBody = map[string]interface{}{
+			"text": localVarTempParam,
+		}
 	}
 
 	// to determine the Content-Type header

--- a/default_api.go
+++ b/default_api.go
@@ -6,6 +6,7 @@ package bitbucketv1
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/url"
 	"strings"

--- a/default_api.go
+++ b/default_api.go
@@ -4703,7 +4703,7 @@ func (a *DefaultApiService) GetGroupsWithoutAnyPermission_14(localVarOptionals m
 }
 
 // AddRepositoryPermissionGroup https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8297426496
-func (a *DefaultApiService) SetRepositoryPermissionGroups(projectKey, repositorySlug, permission, groupNames []string, localVarHTTPContentTypes []string) (*APIResponse, error) {
+func (a *DefaultApiService) SetRepositoryPermissionGroups(projectKey, repositorySlug, permission string, groupNames []string, localVarHTTPContentTypes []string) (*APIResponse, error) {
     var (
         localVarHTTPMethod = strings.ToUpper("Put")
         localVarFileName   string

--- a/default_api.go
+++ b/default_api.go
@@ -13067,8 +13067,6 @@ func (a *DefaultApiService) GetHeadCommit(project, repository, branch string, lo
 	localVarPath = strings.Replace(localVarPath, "{"+"repositorySlug"+"}", fmt.Sprintf("%v", repository), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"branch"+"}", fmt.Sprintf("%v", branch), -1)
 
-	fmt.Println("localVarPath", localVarPath)
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}

--- a/default_api.go
+++ b/default_api.go
@@ -9893,6 +9893,97 @@ func (a *DefaultApiService) SetPermissionForUsers_33(localVarOptionals map[strin
 	return NewBitbucketAPIResponse(localVarHTTPResponse)
 }
 
+
+/**
+https://docs.atlassian.com/bitbucket-server/rest/5.5.2/bitbucket-access-tokens-rest.html
+{
+    "id": "252973515069",
+    "createdDate": 1503289426223,
+    "lastAuthenticated": 1503289517336,
+    "name": "token name",
+    "permissions": [
+        "REPO_ADMIN",
+        "PROJECT_READ"
+    ],
+    "user": {
+        "name": "jcitizen",
+        "emailAddress": "jane@example.com",
+        "id": 101,
+        "displayName": "Jane Citizen",
+        "active": true,
+        "slug": "jcitizen",
+        "type": "NORMAL"
+    },
+    "token": "MjUyOTczNTE1MDY5On2rDbID2EgYpH8AVOECHv0saruQ"
+}
+ @param optional (nil or map[string]interface{}) with one or more of:
+	 @param "name" (string) the names of the users
+	 @param "permission" (string) the permission to grant
+ @return */
+func (a *DefaultApiService) CreateAccessToken(userSlug, tokenName string, repoAdmin, projectRead bool) (*APIResponse, error) {
+	var (
+		localVarHTTPMethod = strings.ToUpper("Put")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+	)
+
+	// create path and map variables
+	// /rest/access-tokens/1.0/users/{userSlug}
+	localVarPath := a.client.cfg.BasePath + "/access-tokens/1.0/users/" + userSlug
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+
+	permissions := make([]string, 0)
+	if repoAdmin {
+		permissions = append(permissions, "REPO_ADMIN")
+	}
+	if projectRead {
+		permissions = append(permissions, "PROJECT_READ")
+	}
+	localVarPostBody = map[string]interface{}{
+		"name":        tokenName,
+		"permissions": permissions,
+	}
+
+	r, err := a.client.prepareRequest(a.client.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return NewBitbucketAPIResponse(localVarHTTPResponse)
+	}
+	defer localVarHTTPResponse.Body.Close()
+	if localVarHTTPResponse.StatusCode >= 300 {
+		bodyBytes, _ := ioutil.ReadAll(localVarHTTPResponse.Body)
+		return NewAPIResponseWithError(localVarHTTPResponse, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
+	}
+
+	return NewBitbucketAPIResponse(localVarHTTPResponse)
+}
+
 /* DefaultApiService
 Set the current log level for the root logger.  &lt;p&gt;  The authenticated user must have &lt;strong&gt;ADMIN&lt;/strong&gt; permission or higher to call this resource.
 * @param ctx context.Context for authentication, logging, tracing, etc.

--- a/default_api.go
+++ b/default_api.go
@@ -7533,15 +7533,15 @@ func (a *DefaultApiService) CreateRepoSSHKey(projectKey, repositorySlug, sshPubK
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	permissions := "REPO_READ"
+	permission := "REPO_READ"
 	if isWrite {
-		permissions = "REPO_WRITE"
+		permission = "REPO_WRITE"
 	}
 	localVarPostBody = map[string]interface{}{
 		"key":        map[string]interface{}{
 			"text": sshPubKey,
 		},
-		"permissions": permissions,
+		"permission": permission,
 	}
 
 	// to determine the Content-Type header

--- a/default_api.go
+++ b/default_api.go
@@ -13044,3 +13044,66 @@ func (a *DefaultApiService) WithdrawApproval(pullRequestID int64) (*APIResponse,
 
 	return NewBitbucketAPIResponse(localVarHTTPResponse)
 }
+
+//  "http://<ourstashurl>/stash/rest/api/latest/projects/<projectname>/repos/<reponame>/commits?at=refs/heads/deploy&start=0&limit=0"
+func (a *DefaultApiService) GetHeadCommit(project, repository, branch string, localVarOptionals map[string]interface{}) (*APIResponse, error) {
+	var (
+		localVarHTTPMethod = strings.ToUpper("Get")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+	)
+	// create path and map variables
+	if err := typeCheckParameter(localVarOptionals["apibasepath"], "string", "apibasepath"); err != nil {
+		return nil, err
+	}
+	apibasepath, _ := localVarOptionals["apibasepath"].(string)
+	if apibasepath == "" {
+		apibasepath = "/api/1.0" // or "apibasepath": "/api/latest"
+	}
+
+	localVarPath := a.client.cfg.BasePath + apibasepath + "/projects/{projectKey}/repos/{repositorySlug}/commits?at=refs/heads/{branch}&start=0&limit=1"
+	localVarPath = strings.Replace(localVarPath, "{"+"projectKey"+"}", fmt.Sprintf("%v", project), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"repositorySlug"+"}", fmt.Sprintf("%v", repository), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"branch"+"}", fmt.Sprintf("%v", branch), -1)
+
+	fmt.Println("localVarPath", localVarPath)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	r, err := a.client.prepareRequest(a.client.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return NewBitbucketAPIResponse(localVarHTTPResponse)
+	}
+	defer localVarHTTPResponse.Body.Close()
+	if localVarHTTPResponse.StatusCode >= 300 {
+		bodyBytes, _ := ioutil.ReadAll(localVarHTTPResponse.Body)
+		return NewAPIResponseWithError(localVarHTTPResponse, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
+	}
+
+	return NewBitbucketAPIResponse(localVarHTTPResponse)
+}

--- a/default_api.go
+++ b/default_api.go
@@ -4148,7 +4148,6 @@ func (a *DefaultApiService) GetRawContent(projectKey, repositorySlug, path strin
 	localVarPath = strings.Replace(localVarPath, "/rest/", "/projects/", 1)
 	// https://bitbucket.global.standardchartered.com/projects/CISO/repos/planes/raw/enactments/tes_mattermost.yaml?at=refs%2Fheads%2Fstate%2Fdev
 	// https://bitbucket.global.standardchartered.com/projects/CISO/repos/planes/raw/enactments/tes_mattermost.yaml?at=refs%2Fheads%2Fstate%2Fdev
-	fmt.Println("localVarPath", localVarPath)
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}

--- a/default_api.go
+++ b/default_api.go
@@ -5,6 +5,8 @@
 package bitbucketv1
 
 import (
+	"errors"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"

--- a/default_api.go
+++ b/default_api.go
@@ -11387,7 +11387,7 @@ func (a *DefaultApiService) StreamDiff_41(path string, localVarOptionals map[str
  @param optional (nil or map[string]interface{}) with one or more of:
 	 @param "at" (string) the commit ID or ref (e.g. a branch or tag) to list the files at.              If not specified the default branch will be used instead.
  @return */
-func (a *DefaultApiService) StreamFiles(localVarOptionals map[string]interface{}) (*APIResponse, error) {
+func (a *DefaultApiService) StreamFiles(projectKey, repositorySlug, path, at string, limit, start int) (*APIResponse, error) {
 	var (
 		localVarHTTPMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -11396,19 +11396,25 @@ func (a *DefaultApiService) StreamFiles(localVarOptionals map[string]interface{}
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/api/1.0/projects/{projectKey}/repos/{repositorySlug}/files"
+	localVarPath := a.client.cfg.BasePath + "/api/1.0/projects/" + projectKey + "/repos/" + repositorySlug + "/files"
+	if path != "" {
+		localVarPath = localVarPath + "/" + path
+	}
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	if err := typeCheckParameter(localVarOptionals["at"], "string", "at"); err != nil {
-		return nil, err
+	if at != "" {
+		localVarQueryParams.Add("at", at)
+	}
+	if limit > 0 {
+		localVarQueryParams.Add("limit", fmt.Sprintf("%d", limit))
+	}
+	if start > 0 {
+		localVarQueryParams.Add("start", fmt.Sprintf("%d", start))
 	}
 
-	if localVarTempParam, localVarOk := localVarOptionals["at"].(string); localVarOk {
-		localVarQueryParams.Add("at", parameterToString(localVarTempParam, ""))
-	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/default_api.go
+++ b/default_api.go
@@ -4135,7 +4135,7 @@ func (a *DefaultApiService) GetContent_10(localVarOptionals map[string]interface
 	 @param "hardwrap" (bool) (Optional) Whether the markup implementation should convert newlines to breaks.                    If not specified, {@link MarkupService} will use the value of the                    &lt;code&gt;markup.render.hardwrap&lt;/code&gt; property, which is &lt;code&gt;true&lt;/code&gt; by default
 	 @param "htmlEscape" (bool) (Optional) true if HTML should be escaped in the input markup, false otherwise.                    If not specified, {@link MarkupService} will use the value of the                    &lt;code&gt;markup.render.html.escape&lt;/code&gt; property, which is &lt;code&gt;true&lt;/code&gt; by default
  @return */
-func (a *DefaultApiService) GetContent_11(path string, localVarOptionals map[string]interface{}) (*APIResponse, error) {
+func (a *DefaultApiService) GetRawContent(projectKey, repositorySlug, path string, localVarOptionals map[string]interface{}) (*APIResponse, error) {
 	var (
 		localVarHTTPMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -4144,9 +4144,11 @@ func (a *DefaultApiService) GetContent_11(path string, localVarOptionals map[str
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/api/1.0/projects/{projectKey}/repos/{repositorySlug}/raw/{path}"
-	localVarPath = strings.Replace(localVarPath, "{"+"path"+"}", fmt.Sprintf("%v", path), -1)
-
+	localVarPath := a.client.cfg.BasePath + "/" + projectKey + "/repos/" + repositorySlug + "/raw/" + path
+	localVarPath = strings.Replace(localVarPath, "/rest/", "/projects/", 1)
+	// https://bitbucket.global.standardchartered.com/projects/CISO/repos/planes/raw/enactments/tes_mattermost.yaml?at=refs%2Fheads%2Fstate%2Fdev
+	// https://bitbucket.global.standardchartered.com/projects/CISO/repos/planes/raw/enactments/tes_mattermost.yaml?at=refs%2Fheads%2Fstate%2Fdev
+	fmt.Println("localVarPath", localVarPath)
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
@@ -4208,7 +4210,9 @@ func (a *DefaultApiService) GetContent_11(path string, localVarOptionals map[str
 		return NewAPIResponseWithError(localVarHTTPResponse, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
 	}
 
-	return NewBitbucketAPIResponse(localVarHTTPResponse)
+	result := NewAPIResponse(localVarHTTPResponse)
+	result.Payload, err = ioutil.ReadAll(localVarHTTPResponse.Body)
+	return result, err
 }
 
 /* DefaultApiService


### PR DESCRIPTION
Hi and thanks for a very useful project.

Here is the bare minimum that I needed to do to be able to use the GetArchive API.

Let me know what it would take to eventually push this back to your repository.

Pass a writer to stream out the content of the archive.
Support for multiple `path` by splitting the path parameter by comma.
Add an optional parameter `apibasepath` that replaces the default base path `/api/1.0` as at least as seen in the wild, this base URL is different.