### PR TITLE
Fixing SetPermissionForGroup

### DIFF
--- a/default_api.go
+++ b/default_api.go
@@ -9415,7 +9415,7 @@ func (a *DefaultApiService) SetMergeConfig(scmId string) (*APIResponse, error) {
 	 @param "permission" (string) the permission to grant
 	 @param "name" (string) the names of the groups
  @return */
-func (a *DefaultApiService) SetPermissionForGroup(localVarOptionals map[string]interface{}) (*APIResponse, error) {
+func (a *DefaultApiService) SetPermissionForGroup(projectKey string, repositorySlug string, localVarOptionals map[string]interface{}) (*APIResponse, error) {
 	var (
 		localVarHTTPMethod = strings.ToUpper("Put")
 		localVarPostBody   interface{}
@@ -9425,7 +9425,9 @@ func (a *DefaultApiService) SetPermissionForGroup(localVarOptionals map[string]i
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/api/1.0/projects/{projectKey}/repos/{repositorySlug}/permissions/groups"
-
+	localVarPath = strings.Replace(localVarPath, "{"+"projectKey"+"}", fmt.Sprintf("%v", projectKey), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"repositorySlug"+"}", fmt.Sprintf("%v", repositorySlug), -1)
+	
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
@@ -9475,7 +9477,8 @@ func (a *DefaultApiService) SetPermissionForGroup(localVarOptionals map[string]i
 		return NewAPIResponseWithError(localVarHTTPResponse, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
 	}
 
-	return NewBitbucketAPIResponse(localVarHTTPResponse)
+	// No body parsing (a successful 204 response has no content)
+	return NewAPIResponse(localVarHTTPResponse), nil
 }
 
 /* DefaultApiService

--- a/default_api_test.go
+++ b/default_api_test.go
@@ -5127,6 +5127,8 @@ func TestDefaultApiService_SetPermissionForGroup(t *testing.T) {
 		client *APIClient
 	}
 	type args struct {
+		projectKey string
+		repositorySlug string
 		localVarOptionals map[string]interface{}
 	}
 	tests := []struct {
@@ -5136,14 +5138,14 @@ func TestDefaultApiService_SetPermissionForGroup(t *testing.T) {
 		want    *APIResponse
 		wantErr bool
 	}{
-		{"networkErrorContextExceeded", fields{client: generateConfigFake()}, args{}, &APIResponse{Message: "Put https://stash.domain.com/rest/api/1.0/projects/%7BprojectKey%7D/repos/%7BrepositorySlug%7D/permissions/groups: context canceled"}, true},
+		{"networkErrorContextExceeded", fields{client: generateConfigFake()}, args{}, &APIResponse{Message: "Put https://stash.domain.com/rest/api/1.0/projects//repos//permissions/groups: context canceled"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &DefaultApiService{
 				client: tt.fields.client,
 			}
-			got, err := a.SetPermissionForGroup(tt.args.localVarOptionals)
+			got, err := a.SetPermissionForGroup(tt.args.projectKey, tt.args.repositorySlug, tt.args.localVarOptionals)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DefaultApiService.SetPermissionForGroup() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
- Adding required parameters `projectKey` and `repositorySlug`
- Removing attempt to parse a 204 response body