### PR TITLE
Fix missing parameter RevokePermissionsForUser

### DIFF
--- a/default_api.go
+++ b/default_api.go
@@ -9055,7 +9055,7 @@ func (a *DefaultApiService) RevokePermissionsForUser(localVarOptionals map[strin
 		return NewAPIResponseWithError(localVarHTTPResponse, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
 	}
 
-	return NewBitbucketAPIResponse(localVarHTTPResponse)
+	return NewAPIResponse(localVarHTTPResponse), nil
 }
 
 /* DefaultApiService
@@ -9064,7 +9064,7 @@ func (a *DefaultApiService) RevokePermissionsForUser(localVarOptionals map[strin
  @param optional (nil or map[string]interface{}) with one or more of:
 	 @param "name" (string) the name of the user
  @return */
-func (a *DefaultApiService) RevokePermissionsForUser_30(localVarOptionals map[string]interface{}) (*APIResponse, error) {
+func (a *DefaultApiService) RevokePermissionsForUser_30(projectKey string, localVarOptionals map[string]interface{}) (*APIResponse, error) {
 	var (
 		localVarHTTPMethod = strings.ToUpper("Delete")
 		localVarPostBody   interface{}
@@ -9074,6 +9074,7 @@ func (a *DefaultApiService) RevokePermissionsForUser_30(localVarOptionals map[st
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/api/1.0/projects/{projectKey}/permissions/users"
+	localVarPath = strings.Replace(localVarPath, "{"+"projectKey"+"}", fmt.Sprintf("%v", projectKey), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -9118,7 +9119,7 @@ func (a *DefaultApiService) RevokePermissionsForUser_30(localVarOptionals map[st
 		return NewAPIResponseWithError(localVarHTTPResponse, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
 	}
 
-	return NewBitbucketAPIResponse(localVarHTTPResponse)
+	return NewAPIResponse(localVarHTTPResponse), nil
 }
 
 /* DefaultApiService
@@ -9127,7 +9128,7 @@ func (a *DefaultApiService) RevokePermissionsForUser_30(localVarOptionals map[st
  @param optional (nil or map[string]interface{}) with one or more of:
 	 @param "name" (string) the name of the user
  @return */
-func (a *DefaultApiService) RevokePermissionsForUser_31(localVarOptionals map[string]interface{}) (*APIResponse, error) {
+func (a *DefaultApiService) RevokePermissionsForUser_31(projectKey string, repositorySlug string, localVarOptionals map[string]interface{}) (*APIResponse, error) {
 	var (
 		localVarHTTPMethod = strings.ToUpper("Delete")
 		localVarPostBody   interface{}
@@ -9137,6 +9138,8 @@ func (a *DefaultApiService) RevokePermissionsForUser_31(localVarOptionals map[st
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/api/1.0/projects/{projectKey}/repos/{repositorySlug}/permissions/users"
+	localVarPath = strings.Replace(localVarPath, "{"+"projectKey"+"}", fmt.Sprintf("%v", projectKey), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"repositorySlug"+"}", fmt.Sprintf("%v", repositorySlug), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -9181,7 +9184,7 @@ func (a *DefaultApiService) RevokePermissionsForUser_31(localVarOptionals map[st
 		return NewAPIResponseWithError(localVarHTTPResponse, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
 	}
 
-	return NewBitbucketAPIResponse(localVarHTTPResponse)
+	return NewAPIResponse(localVarHTTPResponse), nil
 }
 
 /* DefaultApiService

--- a/default_api_test.go
+++ b/default_api_test.go
@@ -4934,6 +4934,7 @@ func TestDefaultApiService_RevokePermissionsForUser_30(t *testing.T) {
 		client *APIClient
 	}
 	type args struct {
+		projectKey        string
 		localVarOptionals map[string]interface{}
 	}
 	tests := []struct {
@@ -4943,14 +4944,14 @@ func TestDefaultApiService_RevokePermissionsForUser_30(t *testing.T) {
 		want    *APIResponse
 		wantErr bool
 	}{
-		{"networkErrorContextExceeded", fields{client: generateConfigFake()}, args{}, &APIResponse{Message: "Delete https://stash.domain.com/rest/api/1.0/projects/%7BprojectKey%7D/permissions/users: context canceled"}, true},
+		{"networkErrorContextExceeded", fields{client: generateConfigFake()}, args{}, &APIResponse{Message: "Delete https://stash.domain.com/rest/api/1.0/projects//permissions/users: context canceled"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &DefaultApiService{
 				client: tt.fields.client,
 			}
-			got, err := a.RevokePermissionsForUser_30(tt.args.localVarOptionals)
+			got, err := a.RevokePermissionsForUser_30(tt.args.projectKey, tt.args.localVarOptionals)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DefaultApiService.RevokePermissionsForUser_30() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -4967,6 +4968,8 @@ func TestDefaultApiService_RevokePermissionsForUser_31(t *testing.T) {
 		client *APIClient
 	}
 	type args struct {
+		projectKey        string
+		repositorySlug    string
 		localVarOptionals map[string]interface{}
 	}
 	tests := []struct {
@@ -4976,14 +4979,14 @@ func TestDefaultApiService_RevokePermissionsForUser_31(t *testing.T) {
 		want    *APIResponse
 		wantErr bool
 	}{
-		{"networkErrorContextExceeded", fields{client: generateConfigFake()}, args{}, &APIResponse{Message: "Delete https://stash.domain.com/rest/api/1.0/projects/%7BprojectKey%7D/repos/%7BrepositorySlug%7D/permissions/users: context canceled"}, true},
+		{"networkErrorContextExceeded", fields{client: generateConfigFake()}, args{}, &APIResponse{Message: "Delete https://stash.domain.com/rest/api/1.0/projects//repos//permissions/users: context canceled"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &DefaultApiService{
 				client: tt.fields.client,
 			}
-			got, err := a.RevokePermissionsForUser_31(tt.args.localVarOptionals)
+			got, err := a.RevokePermissionsForUser_31(tt.args.projectKey, tt.args.repositorySlug, tt.args.localVarOptionals)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DefaultApiService.RevokePermissionsForUser_31() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Variants were missing project and repository slug. Tests changed.
Skipping body parsing as return code is '204' if successful.