### PR TITLE
Option to include request body for enabling hooks

### DIFF
--- a/default_api.go
+++ b/default_api.go
@@ -137,7 +137,7 @@ func (a *DefaultApiService) AddUserToGroups(name string, groups []string) (*APIR
 	)
 
 	localVarPostBody = map[string]interface{}{
-		"user": name,
+		"user":   name,
 		"groups": groups,
 	}
 
@@ -2394,9 +2394,17 @@ func (a *DefaultApiService) EnableHook(projectKey, repositorySlug, hookKey strin
 	 @param "contentLength" (int32)
  @return */
 func (a *DefaultApiService) EnableHook_4(projectKey, repositorySlug, hookKey string, localVarOptionals map[string]interface{}) (*APIResponse, error) {
+	return a.EnableHook_4_WithOptions(projectKey, hookKey, localVarOptionals, nil)
+}
+
+/* DefaultApiService
+For certain hooks (like "com.atlassian.bitbucket.server.bitbucket-bundled-hooks:requiredApproversMergeHook"), a request body with "requiredCount" and an integer value is necessary.
+
+@param localVarPostBody (nil or map[string]interface{})
+@return */
+func (a *DefaultApiService) EnableHook_4_WithOptions(projectKey, hookKey string, localVarOptionals map[string]interface{}, localVarPostBody interface{}) (*APIResponse, error) {
 	var (
 		localVarHTTPMethod = strings.ToUpper("Put")
-		localVarPostBody   interface{}
 		localVarFileName   string
 		localVarFileBytes  []byte
 	)
@@ -2404,7 +2412,6 @@ func (a *DefaultApiService) EnableHook_4(projectKey, repositorySlug, hookKey str
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/api/1.0/projects/{projectKey}/settings/hooks/{hookKey}/enabled"
 	localVarPath = strings.Replace(localVarPath, "{"+"projectKey"+"}", fmt.Sprintf("%v", projectKey), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"repositorySlug"+"}", fmt.Sprintf("%v", repositorySlug), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"hookKey"+"}", fmt.Sprintf("%v", hookKey), -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -2435,6 +2442,7 @@ func (a *DefaultApiService) EnableHook_4(projectKey, repositorySlug, hookKey str
 	if localVarTempParam, localVarOk := localVarOptionals["contentLength"].(int32); localVarOk {
 		localVarHeaderParams["Content-Length"] = parameterToString(localVarTempParam, "")
 	}
+
 	r, err := a.client.prepareRequest(a.client.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err

--- a/default_api_test.go
+++ b/default_api_test.go
@@ -124,7 +124,7 @@ func TestDefaultApiService_AddUserToGroups(t *testing.T) {
 		client *APIClient
 	}
 	type args struct {
-		name string
+		name   string
 		groups []string
 	}
 	tests := []struct {
@@ -1844,6 +1844,45 @@ func TestDefaultApiService_EnableHook_4(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("DefaultApiService.EnableHook_4() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultApiService_EnableHook_4_WithOptions(t *testing.T) {
+	type fields struct {
+		client *APIClient
+	}
+	type args struct {
+		projectKey        string
+		hookKey           string
+		localVarOptionals map[string]interface{}
+		localVarPostBody  map[string]interface{}
+	}
+	tests := []struct {
+		name                     string
+		fields                   fields
+		args                     args
+		want                     *APIResponse
+		wantErr, integrationTest bool
+	}{
+		{"networkErrorContextExceeded", fields{client: generateConfigFake()}, args{}, &APIResponse{Message: "Put https://stash.domain.com/rest/api/1.0/projects//settings/hooks//enabled: context canceled"}, true, false},
+	}
+	for _, tt := range tests {
+		if tt.integrationTest != runIntegrationTests {
+			continue
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			a := &DefaultApiService{
+				client: tt.fields.client,
+			}
+			got, err := a.EnableHook_4_WithOptions(tt.args.projectKey, tt.args.hookKey, tt.args.localVarOptionals, tt.args.localVarPostBody)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DefaultApiService.EnableHook_4_WithOptions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DefaultApiService.EnableHook_4_WithOptions() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Certain hooks require a request body for them to be enabled - ex. "com.atlassian.bitbucket.server.bitbucket-bundled-hooks:requiredApproversMergeHook". This gives the ability to include a request body.