### PR TITLE
Get archive should use RawAPIResponse

### DIFF
--- a/default_api.go
+++ b/default_api.go
@@ -3154,7 +3154,7 @@ func (a *DefaultApiService) GetArchive(project, repository string, localVarOptio
 		return NewAPIResponseWithError(localVarHTTPResponse, bodyBytes, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
 	}
 
-	return NewBitbucketAPIResponse(localVarHTTPResponse)
+	return NewRawAPIResponse(localVarHTTPResponse)
 }
 
 /* DefaultApiService


### PR DESCRIPTION
The response of `/api/1.0/projects/{projectKey}/repos/{repositorySlug}/archive` is a raw zip, tar, or tgz. Therefore trying to decode it to `APIResponse` may fail:
```go
// The following line returns an error:
err := json.NewDecoder(r.Body).Decode(&response.Values)
``` 
I got the following error when trying to download a tar.gz file:
> invalid character '\x1f' looking for beginning of value

The solution that resolved the issue for me is to use RawAPIResponse.