### PR TITLE
Fix set and get commit status

### DIFF
--- a/default_api.go
+++ b/default_api.go
@@ -13562,7 +13562,7 @@ func (a *DefaultApiService) GetCommitStatus(commitId string) (*APIResponse, erro
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/rest/build-status/1.0/commits/{commitId}"
+	localVarPath := a.client.cfg.BasePath + "/build-status/1.0/commits/{commitId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"commitId"+"}", fmt.Sprintf("%v", commitId), -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -13682,7 +13682,7 @@ func (a *DefaultApiService) SetCommitStatus(commitId string, buildStatus BuildSt
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/rest/build-status/1.0/commits/{commitId}"
+	localVarPath := a.client.cfg.BasePath + "/build-status/1.0/commits/{commitId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"commitId"+"}", fmt.Sprintf("%v", commitId), -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -13723,7 +13723,7 @@ func (a *DefaultApiService) SetCommitStatus(commitId string, buildStatus BuildSt
 		return NewAPIResponseWithError(localVarHTTPResponse, bodyBytes, reportError("Status: %v, Body: %s", localVarHTTPResponse.Status, bodyBytes))
 	}
 
-	return NewBitbucketAPIResponse(localVarHTTPResponse)
+	return NewAPIResponse(localVarHTTPResponse), nil
 }
 
 /*

--- a/default_api_test.go
+++ b/default_api_test.go
@@ -8133,7 +8133,7 @@ func TestDefaultApiService_SetCommitStatus(t *testing.T) {
 		want                     *APIResponse
 		wantErr, integrationTest bool
 	}{
-		{"networkErrorContextExceeded", fields{client: generateConfigFake()}, args{}, &APIResponse{Message: "Post https://stash.domain.com/rest/rest/build-status/1.0/commits/: context canceled"}, true, false},
+		{"networkErrorContextExceeded", fields{client: generateConfigFake()}, args{}, &APIResponse{Message: "Post https://stash.domain.com/rest/build-status/1.0/commits/: context canceled"}, true, false},
 	}
 	for _, tt := range tests {
 		if tt.integrationTest != runIntegrationTests {


### PR DESCRIPTION
Fix the following issues:
1. GetCommitStatus and SetCommitStatus expect to get basePath without `/rest`, unlike all other methods. Let's make them work like the others.
2. SetCommitStatus returns 204 No Content. Therefore attempting to decode the body to `APIResponse` results in an error. Let's use `NewAPIResponse` instead of `NewBitbucketAPIResponse`.