### PR TITLE
feat: add GetBranchResponse

### DIFF
--- a/api_response.go
+++ b/api_response.go
@@ -554,6 +554,13 @@ func GetBranchesResponse(r *APIResponse) ([]Branch, error) {
 	return m, err
 }
 
+// GetBrancheResponse cast Branch into structure
+func GetBranchResponse(r *APIResponse) (Branch, error) {
+	var m Branch
+	err := mapstructure.Decode(r.Values, &m)
+	return m, err
+}
+
 // GetRepositoriesResponse cast Repositories into structure
 func GetRepositoriesResponse(r *APIResponse) ([]Repository, error) {
 	var m []Repository

--- a/api_response_test.go
+++ b/api_response_test.go
@@ -115,6 +115,55 @@ func TestGetBranchesResponse(t *testing.T) {
 	}
 }
 
+func TestGetBranchResponse(t *testing.T) {
+	type args struct {
+		r *APIResponse
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Branch
+		wantErr bool
+	}{
+		{
+			name: "Single branch",
+			args: args{
+				r: &APIResponse{
+					Values: map[string]interface{}{
+						"id":              "refs/heads/main",
+						"displayId":       "main",
+						"type":            "BRANCH",
+						"latestCommit":    "8d51122def5632836d1cb1026e879069e10a1e13",
+						"latestChangeset": "8d51122def5632836d1cb1026e879069e10a1e13",
+						"isDefault":       true,
+					},
+				},
+			},
+			want: Branch{
+				ID:              "refs/heads/main",
+				DisplayID:       "main",
+				Type:            "BRANCH",
+				LatestCommit:    "8d51122def5632836d1cb1026e879069e10a1e13",
+				LatestChangeset: "8d51122def5632836d1cb1026e879069e10a1e13",
+				IsDefault:       true,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetBranchResponse(tt.args.r)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetBranchResponse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetBranchResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetRepositoriesResponse(t *testing.T) {
 	type args struct {
 		r *APIResponse


### PR DESCRIPTION
Parse a single Branch from an APIResponse
Useful in combination with the GetDefaultBranch API call