### PR TITLE
fix: support pagination for GetBranches

### DIFF
--- a/default_api.go
+++ b/default_api.go
@@ -3260,7 +3260,19 @@ func (a *DefaultApiService) GetBranches(project, repository string, localVarOpti
 	if err := typeCheckParameter(localVarOptionals["orderBy"], "string", "orderBy"); err != nil {
 		return nil, err
 	}
+	if err := typeCheckParameter(localVarOptionals["limit"], "int", "limit"); err != nil {
+		return nil, err
+	}
+	if err := typeCheckParameter(localVarOptionals["start"], "int", "start"); err != nil {
+		return nil, err
+	}
 
+	if localVarTempParam, localVarOk := localVarOptionals["limit"].(int); localVarOk {
+		localVarQueryParams.Add("limit", parameterToString(localVarTempParam, ""))
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["start"].(int); localVarOk {
+		localVarQueryParams.Add("start", parameterToString(localVarTempParam, ""))
+	}
 	if localVarTempParam, localVarOk := localVarOptionals["base"].(string); localVarOk {
 		localVarQueryParams.Add("base", parameterToString(localVarTempParam, ""))
 	}

--- a/default_api_test.go
+++ b/default_api_test.go
@@ -2365,13 +2365,52 @@ func TestDefaultApiService_GetBranchesPagination(t *testing.T) {
 		context.TODO(),
 		NewConfiguration(ts.URL),
 	)
-	_, err := client.DefaultApi.GetBranches("PROJECT", "REPO", map[string]interface{}{
-		"limit": 100,
-		"start": 0,
-	})
-	if err != nil {
-		t.Errorf("DefaultApiService.GetBranches() error = %v", err)
-		return
+	type fields struct {
+		client *APIClient
+	}
+	type args struct {
+		project           string
+		repository        string
+		localVarOptionals map[string]interface{}
+	}
+	tests := []struct {
+		name                     string
+		fields                   fields
+		args                     args
+		want                     *APIResponse
+		wantErr, integrationTest bool
+	}{
+		{"limitAndStartSet", fields{client: client}, args{
+			project: "PROJECT", repository: "REPO",
+			localVarOptionals: map[string]interface{}{
+				"limit": 100,
+				"start": 0,
+			}}, nil, false, false},
+		{"incorrectLimit", fields{client: client}, args{
+			project: "PROJECT", repository: "REPO",
+			localVarOptionals: map[string]interface{}{
+				"limit": "wrong",
+			}}, nil, true, false},
+		{"incorrectStart", fields{client: client}, args{
+			project: "PROJECT", repository: "REPO",
+			localVarOptionals: map[string]interface{}{
+				"start": "wrong",
+			}}, nil, true, false},
+	}
+	for _, tt := range tests {
+		if tt.integrationTest != runIntegrationTests {
+			continue
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			a := &DefaultApiService{
+				client: tt.fields.client,
+			}
+			_, err := a.GetBranches(tt.args.project, tt.args.repository, tt.args.localVarOptionals)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DefaultApiService.GetBranches() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The docs mention that this is a Paged API, yet there is no support for
limit and start query params.