### PR TITLE
read full request.Body to reuse http/1 connections

### DIFF
--- a/api_response.go
+++ b/api_response.go
@@ -7,6 +7,7 @@ package bitbucketv1
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -668,7 +669,6 @@ func GetActivitiesResponse(r *APIResponse) (Activities, error) {
 
 // NewAPIResponse create new APIResponse from http.Response
 func NewAPIResponse(r *http.Response) *APIResponse {
-
 	response := &APIResponse{Response: r}
 	return response
 }
@@ -688,10 +688,18 @@ func NewAPIResponseWithError(r *http.Response, bodyBytes []byte, err error) (*AP
 // NewBitbucketAPIResponse create new API response from http.response
 func NewBitbucketAPIResponse(r *http.Response) (*APIResponse, error) {
 	response := &APIResponse{Response: r}
-	err := json.NewDecoder(r.Body).Decode(&response.Values)
+
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(&response.Values)
 	if err != nil {
 		return nil, err
 	}
+
+	if decoder.More() {
+		// there's more data in the stream, so discard whatever is left
+		io.Copy(ioutil.Discard, r.Body)
+	}
+
 	return response, err
 }
 


### PR DESCRIPTION
In one of my projects this change dropped the number of GCs by factor 5, as the HTTP connection can be reused if the FULL body is read. 
Without the change ALL API calls need a full handshake (+tls) which is quite heavy. After reading the full body, the connection is put back into the pool and the next API request can reuse it.

see this post and the related pages. https://tipsfordev.com/go-http-requests-json-reusing-connections