### PR TITLE
chore(project): add a single project response

### DIFF
--- a/api_response.go
+++ b/api_response.go
@@ -602,6 +602,13 @@ func GetRepositoriesResponse(r *APIResponse) ([]Repository, error) {
 	return m, err
 }
 
+// GetRepositoryResponse cast project into structure
+func GetRrojectResponse(r *APIResponse) (Project, error) {
+	var m Project
+	err := mapstructure.Decode(r.Values, &m)
+	return m, err
+}
+
 // GetRepositoryResponse cast Repositories into structure
 func GetRepositoryResponse(r *APIResponse) (Repository, error) {
 	var m Repository


### PR DESCRIPTION
- Add a new function `GetRrojectResponse` to cast Repositories into a Project structure
- Use `mapstructure.Decode` to decode values into the Project structure