### PR TITLE
feat: added boostMatches parameter for GetBranches

### DIFF
--- a/default_api.go
+++ b/default_api.go
@@ -3503,6 +3503,9 @@ func (a *DefaultApiService) GetBranches(project, repository string, localVarOpti
 	if err := typeCheckParameter(localVarOptionals["start"], "int", "start"); err != nil {
 		return nil, err
 	}
+	if err := typeCheckParameter(localVarOptionals["boostMatches"], "bool", "boostMatches"); err != nil {
+		return nil, err
+	}
 
 	if localVarTempParam, localVarOk := localVarOptionals["limit"].(int); localVarOk {
 		localVarQueryParams.Add("limit", parameterToString(localVarTempParam, ""))
@@ -3521,6 +3524,9 @@ func (a *DefaultApiService) GetBranches(project, repository string, localVarOpti
 	}
 	if localVarTempParam, localVarOk := localVarOptionals["orderBy"].(string); localVarOk {
 		localVarQueryParams.Add("orderBy", parameterToString(localVarTempParam, ""))
+	}
+	if localVarTempParam, localVarOk := localVarOptionals["boostMatches"].(bool); localVarOk {
+		localVarQueryParams.Add("boostMatches", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}


### PR DESCRIPTION
Bitbucket DC has support parameter `boostMatches` parameter ([see docs](https://developer.atlassian.com/server/bitbucket/rest/v900/api-group-repository/#api-api-latest-projects-projectkey-repos-repositoryslug-branches-get)).

It's useful if we have many branches, especially if "_" as prefix.

For example, without `boostMatches`:
```
 % curl -s --request GET --url 'http://***/rest/api/latest/projects/TEST/repos/test/branches?orderBy=ALPHABETICAL&filterText=bran' --header 'Accept: application/json' --header 'Authorization: Bearer ***'  | jq ".values[]|.displayId"
```
```
"_bran"
"_bran_123"
"bran"
"bran-123"
"bran-bran-bran"
...
```

with `boostMatches`:
```
% curl -s --request GET --url 'http://***/rest/api/latest/projects/TEST/repos/test/branches?orderBy=ALPHABETICAL&filterText=bran&boostMatches=true' --header 'Accept: application/json' --header 'Authorization: Bearer ***'  | jq ".values[]|.displayId"
```
```
"bran"
"bran-123"
"bran-bran-bran"
"bran_123"
"branch1"
...
```